### PR TITLE
fix: homeslider image upload invalid value

### DIFF
--- a/includes/customizer/class-ascent-customizer.php
+++ b/includes/customizer/class-ascent-customizer.php
@@ -651,7 +651,7 @@ if ( ! class_exists( 'Ascent_Customizer' ) ) {
 			$wp_customize->add_setting( 'ascent_theme_options[asc_slider_image_1]', array(
 				'capability' => 'edit_theme_options',
 				'default' => '',
-				'sanitize_callback' => 'ascent_sanitize_file',
+				'sanitize_callback' => 'ascent_sanitize_image',
 			) );
 			$wp_customize->add_control( new WP_Customize_Image_Control(
 			$wp_customize,
@@ -692,7 +692,7 @@ if ( ! class_exists( 'Ascent_Customizer' ) ) {
 
 			$wp_customize->add_setting( 'ascent_theme_options[asc_slider_image_2]', array(
 			  'capability' => 'edit_theme_options',
-			  'sanitize_callback' => 'ascent_sanitize_file',
+			  'sanitize_callback' => 'ascent_sanitize_image',
 			) );
 			$wp_customize->add_control( new WP_Customize_Image_Control(
 			$wp_customize,
@@ -734,7 +734,7 @@ if ( ! class_exists( 'Ascent_Customizer' ) ) {
 			$wp_customize->add_setting( 'ascent_theme_options[asc_slider_image_3]', array(
 			  'capability' => 'edit_theme_options',
 				'default' => '',
-			  'sanitize_callback' => 'ascent_sanitize_file',
+			  'sanitize_callback' => 'ascent_sanitize_image',
 			) );
 			$wp_customize->add_control( new WP_Customize_Image_Control(
 				$wp_customize,
@@ -777,7 +777,7 @@ if ( ! class_exists( 'Ascent_Customizer' ) ) {
 			$wp_customize->add_setting( 'ascent_theme_options[asc_slider_image_4]', array(
 			  'capability' => 'edit_theme_options',
 				'default' => '',
-			  'sanitize_callback' => 'ascent_sanitize_file',
+			  'sanitize_callback' => 'ascent_sanitize_image',
 			) );
 			$wp_customize->add_control( new WP_Customize_Image_Control(
 			$wp_customize,
@@ -819,7 +819,7 @@ if ( ! class_exists( 'Ascent_Customizer' ) ) {
 			$wp_customize->add_setting( 'ascent_theme_options[asc_slider_image_5]', array(
 			  'capability' => 'edit_theme_options',
 				'default' => '',
-			  'sanitize_callback' => 'ascent_sanitize_file',
+			  'sanitize_callback' => 'ascent_sanitize_image',
 			) );
 			$wp_customize->add_control( new WP_Customize_Image_Control(
 			$wp_customize,


### PR DESCRIPTION
This PR fixes invalid value on homepage slider upload in customizer.

Before this PR was introduced: 
![image](https://user-images.githubusercontent.com/33511934/65566666-29b74880-df86-11e9-8727-223417d02173.png)

After PR was introduced:
![image](https://user-images.githubusercontent.com/33511934/65566808-874b9500-df86-11e9-8aed-f3a5cb4f8d9f.png)